### PR TITLE
added fallback zero replacement methods and test

### DIFF
--- a/pipeline/core/workflow/src/main/scala/edu/ucdavis/fiehnlab/ms/carrot/core/workflow/sample/postprocessing/ZeroReplacement.scala
+++ b/pipeline/core/workflow/src/main/scala/edu/ucdavis/fiehnlab/ms/carrot/core/workflow/sample/postprocessing/ZeroReplacement.scala
@@ -150,6 +150,19 @@ class ZeroReplacementProperties {
   var retentionIndexWindowForPeakDetection: Double = 12
 
   /**
+    * Use the mean of the nearest 5 ions of matching mass to the target to estimate the replacement value
+    * if no value is found within the RI window.  Takes precedence over estimateByChromatogramNoise
+    */
+  var estimateByNearestFourIons: Boolean = true
+
+  /**
+    * Estimate noise as the mean of the lowest 5% of ions for the given mass in the entire chromatogram
+    * if no value is found within the RI window and estimateByNearestFourIons is disabled
+    * Likely more expensive, but a statistically reasonable estimate
+    */
+  var estimateByChromatogramNoise: Boolean = false
+
+  /**
     * utilized mass accuracy for searches
     */
   var massAccuracyInDa: Double = 0.1
@@ -161,7 +174,7 @@ class ZeroReplacementProperties {
 }
 
 /**
-  * Finds the noise value for a peak and substract it from the local maximum for the provided ion and mass
+  * Finds the noise value for a peak and subtract it from the local maximum for the provided ion and mass
   *
   */
 @Component
@@ -229,10 +242,8 @@ class SimpleZeroReplacement @Autowired() extends ZeroReplacement {
     logger.debug(s"noise is: ${noise} for target: ${receivedTarget}")
 
     val replacementValueSpectra = rawdata.spectra.filter { spectra =>
-
-      //find the closes possible mass
+      //find the closest possible mass
       includeMass(receivedTarget, filterByMass, spectra)
-
     }
 
     logger.debug(s"found ${replacementValueSpectra.size} spectra, after mass filter for target ${receivedTarget}")
@@ -246,7 +257,35 @@ class SimpleZeroReplacement @Autowired() extends ZeroReplacement {
     //TODO: Gert should check if this makes sense. In case mass isn't there, I create a Corrected Feature using the original QuantifiedSample and RT, RI, scan# from target with 0 intensity.
     val value: (Feature with CorrectedSpectra) = {
       if (filteredByTime.isEmpty) {
-        logger.warn("Created failsafe [Feature with CorrectedSpectra] from target data and 0 intensity")
+        val intensity: Float = {
+          if (zeroReplacementProperties.estimateByNearestFourIons && !replacementValueSpectra.isEmpty) {
+            // estimate the replacement value using the nearest four ions of matching mass
+            val nearestIntensities = replacementValueSpectra
+              .sortBy(x => Math.abs(x.retentionIndex - receivedTarget.retentionIndex))
+              .take(5)
+              .map(x => MassAccuracy.findClosestIon(x, receivedTarget.precursorMass.get).get.intensity)
+
+            val intensity = nearestIntensities.sum / nearestIntensities.length
+            logger.warn(s"Created failsafe [Feature with CorrectedSpectra] from nearest ${nearestIntensities.length} "+
+              "ions with ${intensity} intensity")
+            intensity
+          } else if (zeroReplacementProperties.estimateByChromatogramNoise && !replacementValueSpectra.isEmpty) {
+            // estimate the replacement value by averaging the intensities of the smallest 5% of ions
+            val intensities = replacementValueSpectra
+              .map(x => MassAccuracy.findClosestIon(x, receivedTarget.precursorMass.get).get.intensity)
+              .sorted
+              .take((replacementValueSpectra.length / 20.0 + 1).toInt)
+
+            val intensity = intensities.sum / intensities.length
+            logger.warn(s"Created failsafe [Feature with CorrectedSpectra] from smallest ${intensities.length} "+
+              "ions with ${intensity} intensity")
+            intensity
+          } else {
+            logger.warn("Created failsafe [Feature with CorrectedSpectra] from target data and 0 intensity")
+            0.0f
+          }
+        }
+
         new Feature with CorrectedSpectra {
           override val uniqueMass: Option[Double] = None
           override val signalNoise: Option[Double] = None
@@ -278,7 +317,7 @@ class SimpleZeroReplacement @Autowired() extends ZeroReplacement {
           /**
             * accurate mass of this feature, if applicable
             */
-          override val massOfDetectedFeature: Option[Ion] = Some(Ion(receivedTarget.accurateMass.get, 0.0f))
+          override val massOfDetectedFeature: Option[Ion] = Some(Ion(receivedTarget.accurateMass.get, intensity))
 
           override val retentionIndex: Double = receivedTarget.retentionIndex
         }

--- a/pipeline/core/workflow/src/test/scala/edu/ucdavis/fiehnlab/ms/carrot/core/workflow/sample/postprocessing/SimpleZeroReplacementTest.scala
+++ b/pipeline/core/workflow/src/test/scala/edu/ucdavis/fiehnlab/ms/carrot/core/workflow/sample/postprocessing/SimpleZeroReplacementTest.scala
@@ -64,6 +64,7 @@ class SimpleZeroReplacementTest extends WordSpec with LazyLogging with ShouldMat
     "replaceValue" should {
 
       "replace the null values in the file" in {
+        simpleZeroReplacement.zeroReplacementProperties.estimateByNearestFourIons = false
         val replaced: QuantifiedSample[Double] = simpleZeroReplacement.process(sample, method, Some(rawSample))
 
         replaced.quantifiedTargets.foreach { x =>
@@ -76,7 +77,22 @@ class SimpleZeroReplacementTest extends WordSpec with LazyLogging with ShouldMat
 
         stasis_cli.getTracking(sample.name).status.map(_.value) should contain("replaced")
       }
-    }
 
+      "replace the null values in the file using nearest ion estimation" in {
+        simpleZeroReplacement.zeroReplacementProperties.estimateByNearestFourIons = true
+        val replaced: QuantifiedSample[Double] = simpleZeroReplacement.process(sample, method, Some(rawSample))
+
+        // All target must be nonzero
+        replaced.quantifiedTargets.foreach { x =>
+          logger.info(s"target: ${x.name.get} = ${x.quantifiedValue}")
+          x.quantifiedValue.getOrElse(-1.0) should be > 0.0
+        }
+
+        //all spectra should be the same count as the targets
+        replaced.spectra.size should be(replaced.quantifiedTargets.size)
+
+        stasis_cli.getTracking(sample.name).status.map(_.value) should contain("replaced")
+      }
+    }
   }
 }


### PR DESCRIPTION
Added two methods that were discussed in the meeting:

1) Finding the nearest 2 ions on either side of the target that match by mass and averaging their intensities - since true peaks have low intensity ions at their edges in an EIC and an isolated high intensity ion is quite unlikely, I think this is a reasonable estimate for local intensity replacement

2) Take the EIC of the target mass, take the smallest 5% of peaks and average their intensity.  This is a good estimate of the average "noise" for this particular ion in the chromatogram